### PR TITLE
add BunnyMock#open? mock implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,3 @@
 source 'http://rubygems.org'
 
-gem 'rake', :require => false
-
-# To use debugger
-# gem 'ruby-debug19', :require => 'ruby-debug'
-
-group :development do
-  gem 'simplecov'
-  gem 'pry'
-end
-
-group :test do
-  gem 'rspec'
-  gem 'rspec-given'
-  gem 'guard-rspec'
-  gem 'rb-fsevent'
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,14 @@
+PATH
+  remote: .
+  specs:
+    bunny_mock (0.0.2)
+
 GEM
   remote: http://rubygems.org/
   specs:
-    coderay (1.0.9)
     diff-lcs (1.2.1)
-    guard (1.6.2)
-      listen (>= 0.6.0)
-      lumberjack (>= 1.0.2)
-      pry (>= 0.9.10)
-      terminal-table (>= 1.4.3)
-      thor (>= 0.14.6)
-    guard-rspec (2.5.1)
-      guard (>= 1.1)
-      rspec (~> 2.11)
-    listen (0.7.3)
-    lumberjack (1.0.3)
-    method_source (0.8.1)
     multi_json (1.7.2)
-    pry (0.9.12)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
-      slop (~> 3.4)
     rake (10.0.3)
-    rb-fsevent (0.9.3)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -37,19 +24,15 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    slop (3.4.4)
     sorcerer (0.3.10)
-    terminal-table (1.4.5)
-    thor (0.17.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  guard-rspec
-  pry
+  bundler (~> 1.3)
+  bunny_mock!
   rake
-  rb-fsevent
   rspec
   rspec-given
   simplecov

--- a/bunny_mock.gemspec
+++ b/bunny_mock.gemspec
@@ -1,0 +1,26 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+
+Gem::Specification.new do |s|
+  s.name        = "bunny_mock"
+  s.version     = '0.0.2'
+  s.authors     = ["svs"]
+  s.email       = ["scottwb@gmail.com"]
+  s.homepage    = "https://github.com/scottwb/bunny-mock"
+  s.summary     = %q{Simple Bunny/RabbitMQ mock class in Ruby. Useful for mocking Bunny usage in test code.}
+  s.description = %q{This is a brain-dead-simple mock for the Bunny class provided by the bunny gem, which is a synchronous Ruby RabbitMQ client. If you want to mock out RabbitMQ in your tests and are currently using Bunny, this might be the tool for you.}
+  s.license     = "Apache 2.0"
+
+  s.files         = `git ls-files`.split("\n")
+  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.require_paths = ["lib"]
+
+  # development dependencies
+  s.add_development_dependency('rake')
+  s.add_development_dependency('bundler', '~> 1.3')
+  s.add_development_dependency('rspec')
+  s.add_development_dependency('rspec-given')
+  s.add_development_dependency('simplecov')
+
+end

--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -1,5 +1,10 @@
 class BunnyMock
 
+  def open?
+    true
+  end
+  alias connected? open?
+
   def start
     :connected
   end

--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -53,6 +53,10 @@ class BunnyMock
       exchange.queues << self
     end
 
+    def publish(msg, msg_attrs = {})
+      self.messages << msg
+    end
+
     # Note that this doesn't block waiting for messages like the real world.
     def subscribe(*args, &block)
       while message = messages.shift

--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -21,6 +21,10 @@ class BunnyMock
     nil
   end
 
+  def create_channel
+    self
+  end
+
   def queue(*attrs)
     BunnyMock::Queue.new(*attrs)
   end

--- a/lib/bunny_mock.rb
+++ b/lib/bunny_mock.rb
@@ -1,5 +1,9 @@
 class BunnyMock
 
+  def initialize(connection_string_or_opts = {}, opts = {}, &block)
+    # ignore the options for now
+  end
+
   def open?
     true
   end

--- a/spec/lib/bunny_mock_spec.rb
+++ b/spec/lib/bunny_mock_spec.rb
@@ -64,6 +64,11 @@ end
 describe BunnyMock do
   Given(:bunny) { BunnyMock.new }
 
+  describe "#open?" do
+    Then { bunny.should be_open }
+    Then { bunny.should be_connected }
+  end
+
   describe "#start" do
     Then { bunny.start.should == :connected }
   end

--- a/spec/lib/bunny_mock_spec.rb
+++ b/spec/lib/bunny_mock_spec.rb
@@ -62,7 +62,7 @@ describe "BunnyMock Integration Tests", :integration => true do
 end
 
 describe BunnyMock do
-  Given(:bunny) { BunnyMock.new }
+  Given(:bunny) { BunnyMock.new({}, {}) }
 
   describe "#open?" do
     Then { bunny.should be_open }

--- a/spec/lib/bunny_mock_spec.rb
+++ b/spec/lib/bunny_mock_spec.rb
@@ -69,6 +69,11 @@ describe BunnyMock do
     Then { bunny.should be_connected }
   end
 
+  describe "#create_channel" do
+    # we do not implement Channels but just use self - which implements all needed methods
+    Then { bunny.create_channel.should == bunny }
+  end
+
   describe "#start" do
     Then { bunny.start.should == :connected }
   end

--- a/spec/lib/bunny_mock_spec.rb
+++ b/spec/lib/bunny_mock_spec.rb
@@ -31,18 +31,22 @@ describe "BunnyMock Integration Tests", :integration => true do
     exchange.publish("Message 2")
     exchange.publish("Message 3")
 
+    queue.publish("queue published")
+
     # Verify state of the queue
-    queue.messages.should have(3).messages
+    queue.messages.should have(4).messages
     queue.messages.should == [
       "Message 1",
       "Message 2",
-      "Message 3"
+      "Message 3",
+      "queue published"
     ]
-    queue.snapshot_messages.should have(3).messages
+    queue.snapshot_messages.should have(4).messages
     queue.snapshot_messages.should == [
       "Message 1",
       "Message 2",
-      "Message 3"
+      "Message 3",
+      "queue published"
     ]
 
     # Here's what we expect to happen when we subscribe to this queue.
@@ -50,6 +54,7 @@ describe "BunnyMock Integration Tests", :integration => true do
     handler.should_receive(:handle_message).with("Message 1").ordered
     handler.should_receive(:handle_message).with("Message 2").ordered
     handler.should_receive(:handle_message).with("Message 3").ordered
+    handler.should_receive(:handle_message).with("queue published").ordered
 
     # Read all those messages
     msg_count = 0
@@ -234,7 +239,7 @@ describe BunnyMock::Exchange do
     Then { exchange.should_not be_bound_to("another_queue") }
   end
 
-  describe "#publish" do
+  describe "exchange #publish" do
     Given(:queue1) { BunnyMock::Queue.new("queue1") }
     Given(:queue2) { BunnyMock::Queue.new("queue2") }
     Given { queue1.bind(exchange) }
@@ -244,6 +249,12 @@ describe BunnyMock::Exchange do
     Then { queue1.snapshot_messages.should == ["hello"] }
     Then { queue2.messages.should == ["hello"] }
     Then { queue2.snapshot_messages.should == ["hello"] }
+  end
+  describe "queue #publish" do
+    Given(:queue1) { BunnyMock::Queue.new("queue1") }
+    When { queue1.publish("hello") }
+    Then { queue1.messages.should == ["hello"] }
+    Then { queue1.snapshot_messages.should == ["hello"] }
   end
 
   describe "#method_missing" do


### PR DESCRIPTION
open?/connected? allows to check if the AMQP connection is open.
The mock version simply returns true.

the goal would be to have a more Bunny-like interface and to support no code changes when using a BunnyMock instance. 
